### PR TITLE
フラッシュメッセージ、エラーメッセージを表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :info, :success, :warning, :error
   before_action :require_login
 
   private

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,14 +6,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path # 仮
+      redirect_back_or_to root_path, success: t('.success') # 仮
     else
-      render :new
+      flash.now[:warning] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_path, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,9 +9,10 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)
-      redirect_to root_path  # 仮
+      redirect_to root_path, success: t('.success')  # 仮
     else
-      render :new
+      flash.now[:warning] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <% else %>
       <%= render 'shared/header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert">
+    <ul>
+      <% object.errors.full_messages.each do |message| %>
+        <li class="text-xs "><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,14 @@
+<% flash.each do |message_type, message| %>
+  <% case message_type %>
+  <% when 'success'%>
+    <div class="alert alert-success">
+  <% when 'warning'%>
+    <div class="alert alert-warning">
+  <% when 'error' %>
+    <div class="alert alert-error">
+  <% else  %>
+    <div class="alert alert-info">
+  <% end %>
+      <%= message %>
+    </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,7 @@
   <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
     <div class="card-body">
       <%= form_with model: @user, class: "form-control" do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="form-control">
           <%= f.label :name, class: "label" do %>
             <span class="label-text"><%= User.human_attribute_name(:name) %></span>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -14,6 +14,14 @@ ja:
   users: 
     new:
       to_login_page: '既にアカウントをお持ちの方はこちら'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       to_register_page: 'アカウントをお持ちでない方はこちら'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'


### PR DESCRIPTION
## 概要

issue #21 

## 確認結果
<img width="1440" alt="a8376c85e2a01bbeffb8fff517e054e3" src="https://github.com/yudai-nishimura/shokenekakiuta/assets/105394766/2128ea3d-c313-450f-916e-66c991400592">


## コメント

- デザインは後でやる
- ユーザー登録失敗時、入力欄が狭くなってしまう
- `app/views/shared/_flash_message.html.erb`のコードが
```ruby
<% flash.each do |message_type, message| %>
  <div class="alert alert-<%= message_type %>"><%= message %></div>
<% end %>
```
だとうまくデザインが当たらなかった。

close #21 
